### PR TITLE
Unneeded local variable added in SimpleAtomicLong

### DIFF
--- a/assignments/week-3-assignment-2/src/edu/vuum/mocca/SimpleAtomicLong.java
+++ b/assignments/week-3-assignment-2/src/edu/vuum/mocca/SimpleAtomicLong.java
@@ -30,7 +30,6 @@ class SimpleAtomicLong
      */
     public SimpleAtomicLong(long initialValue)
     {
-        long value = 0;
         // TODO - you fill in here
     }
 


### PR DESCRIPTION
In week 3's skeleton for SimpleAtomicLong, you've added an unneeded local variable in the constructor. This can be confusing for new programmers who might think this is actually a needed variable.

Since the object reference has not yet been returned, and you shouldn't be leaking _this_ in the constructor. The member variable, mValue, should not be accessible to any other threads yet, so race conditions should not be possible.

Also commented on in the course discussion board:
https://class.coursera.org/posa-002/forum/thread?thread_id=710
