### PR TITLE
Make constants final

### DIFF
--- a/assignments/week-5-assignment-4/src/edu/vuum/mocca/PingPongActivity.java
+++ b/assignments/week-5-assignment-4/src/edu/vuum/mocca/PingPongActivity.java
@@ -20,8 +20,8 @@ public class PingPongActivity extends Activity
     private Button mPlayButton;
     
     /** Variables to track state of the game */
-    private static int PLAY = 0;
-    private static int RESET = 1;
+    private static final int PLAY = 0;
+    private static final int RESET = 1;
     private int mGameState = PLAY;
 		
     protected void onCreate(Bundle savedInstanceState) 


### PR DESCRIPTION
Constants should be marked as final. Here two constant values are used as enumerations of possible states, but are not declared final. This is bad practice, as it would allow the programmer to do stupid things like change the meaning of the current state, which could lead to errors.
