### PR TITLE
Enable scrolling in Ping Pong activity

### DIFF
--- a/assignments/week-5-assignment-4/res/layout/activity_ping_pong.xml
+++ b/assignments/week-5-assignment-4/res/layout/activity_ping_pong.xml
@@ -4,23 +4,34 @@
     android:layout_height="match_parent"
     android:orientation="vertical" >
 
-    <TextView
-        android:id="@+id/pingpong_output"
-        android:layout_width="match_parent"
-       	android:layout_height="wrap_content"
-       	android:layout_gravity="top|center"
-       	android:gravity="center"
-       	android:minLines="1"
-       	android:lines="30"
-       	android:maxLines="30"
-       	android:textSize="15sp" />
+    <ScrollView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content" >
+        
+        <LinearLayout
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" >
+            
+            <TextView
+                android:id="@+id/pingpong_output"
+                android:layout_width="match_parent"
+       	        android:layout_height="wrap_content"
+       	        android:layout_gravity="top|center"
+       	        android:gravity="center"
+       	        android:minLines="1"
+       	        android:lines="30"
+       	        android:maxLines="30"
+       	        android:textSize="15sp" />
     
-    <Button
-        android:id="@+id/play_button"
-        android:text="@string/play_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom|center"
-        android:onClick="playButtonClicked" />
+            <Button
+                android:id="@+id/play_button"
+                android:text="@string/play_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="bottom|center"
+                android:onClick="playButtonClicked" />
+        </LinearLayout>
+    </ScrollView>
 
 </LinearLayout>


### PR DESCRIPTION
Adds a ScrollView to enable scrolling in the Ping Pong activity on Android.

This allows usage on lower resolution devices like the Nexus S. All text will be viewable as well as the reset button, albeit requiring that the user scrolls down to see whatever ends up off screen.
