### PR TITLE
Update PingPongActivityTest.java

### DIFF
--- a/assignments/week-5-assignment-4/W5-A4-Android-Test/src/edu/vuum/mocca/test/PingPongActivityTest.java
+++ b/assignments/week-5-assignment-4/W5-A4-Android-Test/src/edu/vuum/mocca/test/PingPongActivityTest.java
@@ -63,6 +63,10 @@ public class PingPongActivityTest
      * this class a @Test method TODO find better explanation, 100%
      * proper.
      */
+     
+     // regular expression constant of things to be removed from comparison strings
+    private static final String WSEXP = "[ \n\r\b\f\t]+"; 
+	
     public void testPlayPingPongButtonPress() throws Exception {
         Thread.sleep(TestOptions.ACCEPTABLE_STARTUP_LENGTH);
 
@@ -75,7 +79,7 @@ public class PingPongActivityTest
         // wait for the threads to execute
         Thread.sleep(TestOptions.ACCEPTABLE_RUNTIME_LENGTH);
 
-        assertTrue(outputTextView_.getText().toString()
-                   .equals(TestOptions.ANDROID_TEXTVIEW));
+        assertTrue(outputTextView_.getText().toString().replaceAll(WSEXP , "")
+                   .equals(TestOptions.ANDROID_TEXTVIEW.replaceAll(WSEXP , "")));
     }
 }


### PR DESCRIPTION
Modified test to ignore linefeeds and white spaces in the test results. 
This will allow a test to pass even if a line feed or tab is in the wrong position.

Initially I inserted my line feed before the output string. This change will allow before, after or no linefeed to pass. I admit no linefeed would result in an ugly display, but the underlying code would still be functionally correct.
